### PR TITLE
Fix missing navigation import

### DIFF
--- a/app/src/main/java/com/hmu/electrical/MainActivity.kt
+++ b/app/src/main/java/com/hmu/electrical/MainActivity.kt
@@ -11,6 +11,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.hmu.electrical.navigation.Screen
+import com.hmu.electrical.navigation.screens
 import com.hmu.electrical.screens.*
 import com.hmu.electrical.ui.theme.HMUAppTheme
 


### PR DESCRIPTION
## Summary
- fix missing import for `screens` list

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ff6d1df2083328c27b6f57b22fa2d