### PR TITLE
Fix compose compiler Kotlin version mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A modern Android application for Hellenic Mediterranean University - Electrical 
 
 - Android Studio Hedgehog | 2023.1.1 or newer
 - Android SDK 34
-- Kotlin 1.9.0
+- Kotlin 1.9.20
 - Gradle 8.1.0
 
 ## Getting Started

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 
 ext {
     compose_version = '1.5.4'
-    kotlin_version = '1.9.0'
+    kotlin_version = '1.9.20'
 }
 
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
     }
     plugins {
         id 'com.android.application' version '8.1.0'
-        id 'org.jetbrains.kotlin.android' version '1.9.0'
+        id 'org.jetbrains.kotlin.android' version '1.9.20'
     }
 }
 


### PR DESCRIPTION
## Summary
- fix version mismatch between Compose Compiler and Kotlin
- update README requirements

## Testing
- `gradle tasks --no-daemon`
- `gradle build --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ff840fac48332809b7b2e06db899f