### PR TITLE
Fix Kotlin compile error

### DIFF
--- a/app/src/main/java/com/hmu/electrical/screens/MoreScreen.kt
+++ b/app/src/main/java/com/hmu/electrical/screens/MoreScreen.kt
@@ -2,6 +2,7 @@ package com.hmu.electrical.screens
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*


### PR DESCRIPTION
## Summary
- fix missing import for `Modifier.clickable`

## Testing
- `gradle :app:compileDebugKotlin -x lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ffa6e4fa0833281ab65188a4b943b